### PR TITLE
Add duplicate task checking functionality

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,8 @@ tasks.withType(Test) {
 // to fix Error: Could not find or load main class seedu.duke.Duke
 // use package path
 application {
-    mainClassName = 'bytebuddy.ByteBuddy'
+    // mainClassName = 'bytebuddy.ByteBuddy'
+    mainClassName = 'bytebuddy.gui.Launcher'
 }
 
 // JAR output is in build/libs

--- a/data/output.txt
+++ b/data/output.txt
@@ -1,4 +1,5 @@
 D | 1 | return book | 2 December 2019, 6PM
 T | 1 | read book
 T | 0 | run away
-T | 0 | testGUI
+T | 1 | test gui
+T | 1 | test todo duplication

--- a/src/main/java/bytebuddy/constants/ExceptionErrorMessages.java
+++ b/src/main/java/bytebuddy/constants/ExceptionErrorMessages.java
@@ -9,4 +9,5 @@ public class ExceptionErrorMessages {
     public static final String NUMBER_FORMAT_ERROR_MESSAGE = "Invalid task number format! Please enter a valid number.";
     public static final String NO_SUCH_TASK_NUMBER_ERROR_MESSAGE = "We do not have this task number!!";
     public static final String FAILED_WRITE_TO_FILE_ERROR_MESSAGE = "Failed to write to file";
+    public static final String DUPLICATE_TASK_ERROR_MESSAGE = "This task already exists!";
 }

--- a/src/main/java/bytebuddy/tasks/Deadline.java
+++ b/src/main/java/bytebuddy/tasks/Deadline.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -102,6 +103,39 @@ public class Deadline extends Task {
     public String getTextFormattedOutput() {
         int intIsDone = isDone ? 1 : 0;
         return String.format("D | %d | %s | %s", intIsDone, description, by);
+    }
+
+    /**
+     * Indicates whether some other object is "equal to" this one.
+     * This method considers two Deadline objects equal if they have the same description, completion status,
+     * and deadline.
+     *
+     * @param obj the reference object with which to compare.
+     * @return true if this Deadline is the same as the obj argument; false otherwise.
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        Deadline deadline = (Deadline) obj;
+        return isDone == deadline.isDone
+                && Objects.equals(description, deadline.description)
+                && Objects.equals(by, deadline.by);
+    }
+
+    /**
+     * Returns a hash code value for the Deadline object. This method is supported for the benefit of
+     * hash tables such as those provided by HashMap.
+     *
+     * @return a hash code value for this object.
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(description, isDone, by);
     }
 
     /**

--- a/src/main/java/bytebuddy/tasks/Event.java
+++ b/src/main/java/bytebuddy/tasks/Event.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -133,6 +134,41 @@ public class Event extends Task {
         int intIsDone = isDone ? 1 : 0;
         return String.format("E | %d | %s | %s | %s", intIsDone, description, from, to);
     }
+
+    /**
+     * Indicates whether some other object is "equal to" this one.
+     * This method considers two Event objects equal if they have the same description, completion status,
+     * start time, and end time.
+     *
+     * @param obj the reference object with which to compare.
+     * @return true if this Event is the same as the obj argument; false otherwise.
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        Event event = (Event) obj;
+        return isDone == event.isDone
+                && Objects.equals(description, event.description)
+                && Objects.equals(from, event.from)
+                && Objects.equals(to, event.to);
+    }
+
+    /**
+     * Returns a hash code value for the Event object. This method is supported for the benefit of
+     * hash tables such as those provided by HashMap.
+     *
+     * @return a hash code value for this object.
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(description, isDone, from, to);
+    }
+
 
     /**
      * Returns a string representation of the Event task.

--- a/src/main/java/bytebuddy/tasks/Task.java
+++ b/src/main/java/bytebuddy/tasks/Task.java
@@ -3,7 +3,7 @@ package bytebuddy.tasks;
 /**
  * The Task class represents a task with a description and completion status.
  */
-public class Task {
+public abstract class Task {
     protected String description;
     protected boolean isDone;
 
@@ -76,13 +76,31 @@ public class Task {
     }
 
     /**
-     * Returns a formatted string representation of the task for writing into output file.
+     * Returns a formatted string representation of the task for writing into an output file.
+     * Subclasses must implement this method to provide specific formatting for each type of task.
      *
      * @return A formatted string representation of the task.
      */
-    public String getTextFormattedOutput() {
-        return "";
-    }
+    public abstract String getTextFormattedOutput();
+
+    /**
+     * Indicates whether some other object is "equal to" this one.
+     * Subclasses must override this method to define their own equality criteria.
+     *
+     * @param obj The reference object with which to compare.
+     * @return {@code true} if this object is the same as the obj argument; {@code false} otherwise.
+     */
+    @Override
+    public abstract boolean equals(Object obj);
+
+    /**
+     * Returns a hash code value for the object.
+     * Subclasses must override this method to generate a hash code consistent with the equals method.
+     *
+     * @return A hash code value for this object.
+     */
+    @Override
+    public abstract int hashCode();
 
     /**
      * Returns a string representation of the task, including its status icon and description.

--- a/src/main/java/bytebuddy/tasks/TaskList.java
+++ b/src/main/java/bytebuddy/tasks/TaskList.java
@@ -1,5 +1,6 @@
 package bytebuddy.tasks;
 
+import static bytebuddy.constants.ExceptionErrorMessages.DUPLICATE_TASK_ERROR_MESSAGE;
 import static bytebuddy.constants.ExceptionErrorMessages.EMPTY_DESCRIPTION_ERROR_MESSAGE;
 import static bytebuddy.constants.ExceptionErrorMessages.EMPTY_KEYWORD_ERROR_MESSAGE;
 import static bytebuddy.constants.ExceptionErrorMessages.FAILED_WRITE_TO_FILE_ERROR_MESSAGE;
@@ -15,6 +16,7 @@ import static bytebuddy.ui.Ui.printWithSolidLineBreak;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 
 import bytebuddy.exceptions.ByteBuddyException;
@@ -26,6 +28,7 @@ import javafx.util.Pair;
  * provides methods to manipulate and interact with the task list.
  */
 public class TaskList {
+    private HashSet<Task> taskSet;
     private ArrayList<Task> taskList;
 
     /**
@@ -33,6 +36,7 @@ public class TaskList {
      */
     public TaskList() {
         taskList = new ArrayList<>();
+        taskSet = new HashSet<>();
     }
 
     /**
@@ -49,6 +53,7 @@ public class TaskList {
      */
     public void clear() {
         taskList.clear();
+        taskSet.clear();
     }
 
     /**
@@ -58,7 +63,8 @@ public class TaskList {
      * @return true if the task list contains the specified task, false otherwise.
      */
     public boolean contains(Task t) {
-        return taskList.contains(t);
+        // return taskList.contains(t);
+        return taskSet.contains(t);
     }
 
     /**
@@ -77,7 +83,12 @@ public class TaskList {
      * @param t The task to add.
      * @return true if the task was added successfully, false otherwise.
      */
-    public boolean add(Task t) {
+    public boolean add(Task t) throws ByteBuddyException {
+        if (this.contains(t)) {
+            throw new ByteBuddyException(DUPLICATE_TASK_ERROR_MESSAGE);
+        }
+
+        taskSet.add(t);
         return taskList.add(t);
     }
 
@@ -88,6 +99,7 @@ public class TaskList {
      * @return The removed task.
      */
     public Task remove(int index) {
+        taskSet.remove(this.get(index));
         return taskList.remove(index);
     }
 
@@ -165,6 +177,8 @@ public class TaskList {
                 // throw new ByteBuddyException(NO_SUCH_TASK_NUMBER_ERROR_MESSAGE);
                 return "\t " + NO_SUCH_TASK_NUMBER_ERROR_MESSAGE;
             }
+
+            taskSet.remove(this.get(deleteIndex));
             Task removed = taskList.remove(deleteIndex);
             printTaskRemovedWithSolidLineBreak(removed);
 
@@ -193,7 +207,7 @@ public class TaskList {
                 return "\t " + EMPTY_DESCRIPTION_ERROR_MESSAGE;
             }
             Task todo = new Todo(info);
-            taskList.add(todo);
+            this.add(todo);
             printTaskAddedWithSolidLineBreak(todo);
 
             writeToFile(RELATIVE_OUTPUT_TXT_FILE_PATH, getTaskListFormattedStringOutput(taskList));
@@ -202,6 +216,8 @@ public class TaskList {
         } catch (IOException e) {
             // throw new ByteBuddyException(FAILED_WRITE_TO_FILE_ERROR_MESSAGE);
             return "\t " + FAILED_WRITE_TO_FILE_ERROR_MESSAGE;
+        } catch (ByteBuddyException e) {
+            return "\t " + e.getMessage();
         }
     }
 
@@ -219,7 +235,7 @@ public class TaskList {
             }
             List<String> deadlineInfo = splitStringWithTrim(info, "/by", 2);
             Task deadline = new Deadline(deadlineInfo.get(0), deadlineInfo.get(1));
-            taskList.add(deadline);
+            this.add(deadline);
             printTaskAddedWithSolidLineBreak(deadline);
 
             writeToFile(RELATIVE_OUTPUT_TXT_FILE_PATH, getTaskListFormattedStringOutput(taskList));
@@ -231,6 +247,8 @@ public class TaskList {
         } catch (IOException e) {
             // throw new ByteBuddyException(FAILED_WRITE_TO_FILE_ERROR_MESSAGE);
             return "\t " + FAILED_WRITE_TO_FILE_ERROR_MESSAGE;
+        } catch (ByteBuddyException e) {
+            return "\t " + e.getMessage();
         }
     }
 
@@ -250,7 +268,7 @@ public class TaskList {
 
             List<String> eventInfo = splitStringWithTrim(info, "/from|/to", 3);
             Task event = new Event(eventInfo.get(0), eventInfo.get(1), eventInfo.get(2));
-            taskList.add(event);
+            this.add(event);
             printTaskAddedWithSolidLineBreak(event);
 
             writeToFile(RELATIVE_OUTPUT_TXT_FILE_PATH, getTaskListFormattedStringOutput(taskList));
@@ -262,6 +280,8 @@ public class TaskList {
         } catch (IOException e) {
             // throw new ByteBuddyException(FAILED_WRITE_TO_FILE_ERROR_MESSAGE);
             return FAILED_WRITE_TO_FILE_ERROR_MESSAGE;
+        } catch (ByteBuddyException e) {
+            return "\t " + e.getMessage();
         }
     }
 

--- a/src/main/java/bytebuddy/tasks/Todo.java
+++ b/src/main/java/bytebuddy/tasks/Todo.java
@@ -1,5 +1,7 @@
 package bytebuddy.tasks;
 
+import java.util.Objects;
+
 /**
  * The Todo class represents a simple task without a specified deadline or duration.
  * It extends the Task class and provides specific implementations for task creation and string representations.
@@ -34,6 +36,36 @@ public class Todo extends Task {
     public String getTextFormattedOutput() {
         int intIsDone = isDone ? 1 : 0;
         return String.format("T | %d | %s", intIsDone, description);
+    }
+
+    /**
+     * Indicates whether some other object is "equal to" this one.
+     * This method considers two Todo objects equal if they have the same description and completion status.
+     *
+     * @param obj the reference object with which to compare.
+     * @return true if this Todo is the same as the obj argument; false otherwise.
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        Todo todo = (Todo) obj;
+        return isDone == todo.isDone && Objects.equals(description, todo.description);
+    }
+
+    /**
+     * Returns a hash code value for the Todo object. This method is supported for the benefit of
+     * hash tables such as those provided by HashMap.
+     *
+     * @return a hash code value for this object.
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(description, isDone);
     }
 
     /**

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -12,7 +12,7 @@
         <Button fx:id="sendButton" layoutX="524.0" layoutY="558.0" mnemonicParsing="false" onAction="#handleUserInput" prefHeight="41.0" prefWidth="76.0" text="Send" />
         <ScrollPane fx:id="scrollPane" hbarPolicy="NEVER" hvalue="1.0" prefHeight="557.0" prefWidth="600.0" vvalue="1.0">
             <content>
-                <VBox fx:id="dialogContainer" prefHeight="552.0" prefWidth="588.0" />
+                <VBox fx:id="dialogContainer" prefWidth="588.0" />
             </content>
         </ScrollPane>
     </children>

--- a/src/test/java/bytebuddy/tasks/TaskListTest.java
+++ b/src/test/java/bytebuddy/tasks/TaskListTest.java
@@ -167,7 +167,7 @@ public class TaskListTest {
     }
 
     @Test
-    public void testPrintTaskList() {
+    public void testPrintTaskList() throws ByteBuddyException {
         // Redirect System.out for testing print output
         ByteArrayOutputStream outContent = new ByteArrayOutputStream();
         System.setOut(new PrintStream(outContent));

--- a/src/test/java/bytebuddy/tasks/TaskTest.java
+++ b/src/test/java/bytebuddy/tasks/TaskTest.java
@@ -11,9 +11,9 @@ public class TaskTest {
 
     @Test
     public void testTaskMarkAsDone() {
-        Task task = new Task("Sample task");
+        Task task = new Todo("Sample task");
 
-        String expectedOutput = "Nice! I've mark this task as done:\n\t\t[✓] " + task.description;
+        String expectedOutput = "Nice! I've mark this task as done:\n\t\t[T][✓] " + task.description;
         String actualOutput = task.markAsDone();
 
         assertEquals(expectedOutput, actualOutput);
@@ -22,9 +22,9 @@ public class TaskTest {
 
     @Test
     public void testTaskUnmarkAsDone() {
-        Task task = new Task("Sample task", true);
+        Task task = new Todo("1", "Sample task");
 
-        String expectedOutput = "OK, I've marked this task as not done yet:\n\t\t[✕] " + task.description;
+        String expectedOutput = "OK, I've marked this task as not done yet:\n\t\t[T][✕] " + task.description;
         String actualOutput = task.unmarkAsDone();
 
         assertEquals(expectedOutput, actualOutput);
@@ -33,7 +33,7 @@ public class TaskTest {
 
     @Test
     public void testGetStatusIcon() {
-        Task task = new Task("Sample task");
+        Task task = new Todo("Sample task");
         task.markAsDone();
 
         String expectedOutput = "✓";
@@ -44,9 +44,9 @@ public class TaskTest {
 
     @Test
     public void testTaskToString() {
-        Task task = new Task("Sample task", true);
+        Task task = new Todo("1", "Sample task");
 
-        String expectedOutput = "[" + task.getStatusIcon() + "] Sample task";
+        String expectedOutput = "[T][" + task.getStatusIcon() + "] Sample task";
         String actualOutput = task.toString();
 
         assertEquals(expectedOutput, actualOutput);


### PR DESCRIPTION
The current implementation lacks support for checking duplicate tasks, leading to potential inconsistencies in task management.

To enhance the reliability and efficiency of task management, it's essential to prevent the addition of duplicate tasks. This ensures that tasks are unique and eliminates redundancy.

Additional changes:
Configure ./gradlew run to start GUI instead of text-based interface.